### PR TITLE
Update links to docs.hubverse.io

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -35,7 +35,7 @@ website:
           href: quickstart/support-consulting.md
         - icon: book
           text: "Documentation {{< fa arrow-up-right-from-square >}}"
-          href: https://hubverse.io/
+          href: https://docs.hubverse.io/
       - text: "Tools"
         menu:
         - text: "Data Standards"
@@ -51,7 +51,7 @@ website:
         - text: "{{< fa book >}} Resources"
         - "terminology.qmd"
         - text: "Documentation {{< fa arrow-up-right-from-square >}}"
-          href: https://hubverse.io/
+          href: https://docs.hubverse.io/
         - "CONTRIBUTING.md"
       - text: "About"
         menu:
@@ -69,7 +69,7 @@ website:
         - text: "{{< fa book >}} Resources"
         - "terminology.qmd"
         - text: "Documentation {{< fa arrow-up-right-from-square >}}"
-          href: https://hubverse.io/
+          href: https://docs.hubverse.io/
         - text: "Funding"
           href: "funding.md"
         - "CONTRIBUTING.md"

--- a/_snippets/create.qmd
+++ b/_snippets/create.qmd
@@ -5,9 +5,9 @@
 
 #### Creating a hub
 
-[{{< fa forward-fast >}} quickstart](https://hubverse.io/en/latest/quickstart-hub-admin/intro.html){.btn .btn-outline-dark .ms-auto}
+[{{< fa forward-fast >}} quickstart](https://docs.hubverse.io/en/latest/quickstart-hub-admin/intro.html){.btn .btn-outline-dark .ms-auto}
 [{{< fa wrench >}} Setting up a hub](https://hubverse-org.github.io/hubAdmin/articles/hub-setup.html){.btn .btn-outline-dark .ms-auto}
-[{{< fa book >}} Defining model tasks](https://hubverse.io/en/latest/user-guide/tasks.html){.btn .btn-outline-dark .ms-auto}
+[{{< fa book >}} Defining model tasks](https://docs.hubverse.io/en/latest/user-guide/tasks.html){.btn .btn-outline-dark .ms-auto}
 
 To create a hub, you can start with [the hubTemplate](https://github.com/hubverse-org/hubTemplate).
 
@@ -21,7 +21,7 @@ To create a hub, you can start with [the hubTemplate](https://github.com/hubvers
 
 #### Setting up a dashboard
 
-[{{< fa book >}} Building a dashboard](https://hubverse.io/en/latest/user-guide/dashboards.html#quickstart-building-a-dashboard){.btn .btn-outline-dark .ms-auto}
+[{{< fa book >}} Building a dashboard](https://docs.hubverse.io/en/latest/user-guide/dashboards.html#quickstart-building-a-dashboard){.btn .btn-outline-dark .ms-auto}
 
 To set up a dashboard, follow the instructions in the [hub dashboard template](https://github.com/hubverse-org/hub-dashboard-template#readme).
 

--- a/_snippets/develop.qmd
+++ b/_snippets/develop.qmd
@@ -1,9 +1,9 @@
 [{{< fa box-open >}} hubUtils](https://hubverse-org.github.io/hubUtils){.btn .btn-outline-info .ms-auto}
 [{{< fa box-open >}} hubDevs](https://hubverse-org.github.io/hubDevs){.btn .btn-outline-info .ms-auto}
-[{{< fa book >}} Developer Guide](https://hubverse.io/en/latest/developer/index.html){.btn .btn-outline-dark .ms-auto}
+[{{< fa book >}} Developer Guide](https://docs.hubverse.io/en/latest/developer/index.html){.btn .btn-outline-dark .ms-auto}
 
 If you want to help contribute code to the hubverse, it is important to consult
-[the developer guide](https://hubverse.io/en/latest/developer/index.html).
+[the developer guide](https://docs.hubverse.io/en/latest/developer/index.html).
 
 #### Contributing to existing software
 

--- a/_snippets/hub-info.qmd
+++ b/_snippets/hub-info.qmd
@@ -2,7 +2,7 @@
 
 The **hubUtils** R package provides utilities that give you useful information about a hub:
 
- - fetch a hub [**configuration file**](https://hubverse.io/en/latest/user-guide/hub-config.html) with [`hubUtils::read_config()`](https://hubverse-org.github.io/hubUtils/reference/read_config.html)
+ - fetch a hub [**configuration file**](https://docs.hubverse.io/en/latest/user-guide/hub-config.html) with [`hubUtils::read_config()`](https://hubverse-org.github.io/hubUtils/reference/read_config.html)
  - get the submission **timezone** with [`hubUtils::get_hub_timezone()`](https://hubverse-org.github.io/hubUtils/reference/get_hub_timezone.html)
  - find out what the submission **rounds** are with [`hubUtils::get_round_ids()`](https://hubverse-org.github.io/hubUtils/reference/get_round_idx.html)
  - **task ID names** with [`hubUtils::get_task_id_names()`](https://hubverse-org.github.io/hubUtils/reference/get_task_id_names.html)

--- a/_snippets/model-submission.qmd
+++ b/_snippets/model-submission.qmd
@@ -13,8 +13,8 @@ Useful tools are available in the **hubValidations** R package.
  - Create a **submission template** with [`hubValidations::submission_tmpl()`](https://hubverse-org.github.io/hubValidations/reference/submission_tmpl.html)
  - **Validate** your submission with [`hubValidaitons::validate_submission()`](https://hubverse-org.github.io/hubValidations/reference/validate_submission.html)
 
-[{{< fa book >}} Model metadata](https://hubverse.io/en/latest/user-guide/model-metadata.html){.btn .btn-outline-dark .ms-auto}
-[{{< fa book >}} Writing model output to a hub](https://hubverse.io/en/latest/user-guide/model-output.html#writing-model-output-to-a-hub){.btn .btn-outline-dark .ms-auto}
+[{{< fa book >}} Model metadata](https://docs.hubverse.io/en/latest/user-guide/model-metadata.html){.btn .btn-outline-dark .ms-auto}
+[{{< fa book >}} Writing model output to a hub](https://docs.hubverse.io/en/latest/user-guide/model-output.html#writing-model-output-to-a-hub){.btn .btn-outline-dark .ms-auto}
 [{{< fa file-circle-check >}} Validate model submission](https://hubverse-org.github.io/hubValidations/articles/validate-submission.html){.btn .btn-outline-dark .ms-auto}
 
 ::::{.callout-tip collapse="true"}

--- a/quickstart/create.qmd
+++ b/quickstart/create.qmd
@@ -17,8 +17,8 @@ A modeling task focuses on a single target and is made up of a unique
 combination of variables used for modeling and the output types. These variables
 are collectively known as **task IDs**.
 
-[{{< fa compass-drafting >}} Follow the quickstart guide](https://hubverse.io/en/latest/quickstart-hub-admin/intro.html){.btn .btn-outline-dark .ms-auto}
-[{{< fa book >}} Hub configuration files](https://hubverse.io/en/latest/user-guide/hub-config.html){.btn .btn-outline-dark .ms-auto}
+[{{< fa compass-drafting >}} Follow the quickstart guide](https://docs.hubverse.io/en/latest/quickstart-hub-admin/intro.html){.btn .btn-outline-dark .ms-auto}
+[{{< fa book >}} Hub configuration files](https://docs.hubverse.io/en/latest/user-guide/hub-config.html){.btn .btn-outline-dark .ms-auto}
 
 ## Create your hub
 

--- a/terminology.qmd
+++ b/terminology.qmd
@@ -82,7 +82,7 @@ representing the outcomes of multiple efforts.
 : a collection of conditions, assumptions, and potentially [targets](#target)
   that are used to parameterize a model task. These represent columns in the 
   [model output](#model-output). A more [detailed explanation of task ID
-  variables](https://hubverse.io/en/latest/user-guide/tasks.html#task-id-variables)
+  variables](https://docs.hubverse.io/en/latest/user-guide/tasks.html#task-id-variables)
   can be found in the documentaiton.
 
 

--- a/tools/dashboards.qmd
+++ b/tools/dashboards.qmd
@@ -28,7 +28,7 @@ given hub.
 Forecast and Evaluation dashboards for the FluSight forecast hub.
 :::
 
-[{{< fa book >}} Get started with dashboards](https://hubverse.io/en/latest/user-guide/dashboards.html){.btn .btn-outline-dark .ms-auto}
+[{{< fa book >}} Get started with dashboards](https://docs.hubverse.io/en/latest/user-guide/dashboards.html){.btn .btn-outline-dark .ms-auto}
 
 ## Examples
 

--- a/tools/data.qmd
+++ b/tools/data.qmd
@@ -9,9 +9,9 @@ hub.
 
 :::
 
-[{{< fa compass-drafting >}} Model Tasks Schema](https://hubverse.io/en/latest/user-guide/hub-config.html#model-tasks-schema){.btn .btn-outline-dark .ms-auto}
-[{{< fa bullseye >}} Target Data Formats](https://hubverse.io/en/latest/user-guide/target-data.html){.btn .btn-outline-dark .ms-auto}
-[{{< fa file-circle-check>}} Model Output Formats](https://hubverse.io/en/latest/user-guide/model-output.html){.btn .btn-outline-dark .ms-auto}
+[{{< fa compass-drafting >}} Model Tasks Schema](https://docs.hubverse.io/en/latest/user-guide/hub-config.html#model-tasks-schema){.btn .btn-outline-dark .ms-auto}
+[{{< fa bullseye >}} Target Data Formats](https://docs.hubverse.io/en/latest/user-guide/target-data.html){.btn .btn-outline-dark .ms-auto}
+[{{< fa file-circle-check>}} Model Output Formats](https://docs.hubverse.io/en/latest/user-guide/model-output.html){.btn .btn-outline-dark .ms-auto}
 
 The core of the hubverse are the **robust and flexible data standards** that
 allow administrators to write **structured guidelines** for tabular model
@@ -22,7 +22,7 @@ output submissions that can be **easily validated, ensembled, and visualized**.
 
 ## Understanding Model Tasks
 
-Each hub starts with a file called `hub-config/tasks.json` that defines [**model tasks**](https://hubverse.io/en/latest/user-guide/tasks.html) and **frequency of submission**. The structure of this file is defined by [the hubverse model tasks schema](https://hubverse.io/en/latest/user-guide/dashboards.html).
+Each hub starts with a file called `hub-config/tasks.json` that defines [**model tasks**](https://docs.hubverse.io/en/latest/user-guide/tasks.html) and **frequency of submission**. The structure of this file is defined by [the hubverse model tasks schema](https://docs.hubverse.io/en/latest/user-guide/dashboards.html).
 
 The `tasks.json` file is responsible for validation of all model submissions
 and ensures that data are inter-operable.
@@ -32,16 +32,16 @@ tabular model submission against one or more modeling targets. It includes
 three properties:
 
 1. [**Task ID
-   variables**](https://hubverse.io/en/latest/user-guide/tasks.html#usage-of-task-id-variables):
+   variables**](https://docs.hubverse.io/en/latest/user-guide/tasks.html#usage-of-task-id-variables):
    a collection of variables and their expected values used for modeling
    efforts (for example: `target` (incident hospitalizations), `location`
    (Massachusettes), `reference_date` (2025-04-16), and `horizon` (-1))
 2. [**Output
-   types**](https://hubverse.io/en/latest/user-guide/tasks.html#output-types):
+   types**](https://docs.hubverse.io/en/latest/user-guide/tasks.html#output-types):
    The method modelers should use to summarize the results of their modeling
    efforts (for example: the `quantile` probabilities 0.01, 0.025, 0.5, 0.975, 0.99)
 3. [**Target
-   metadata**](https://hubverse.io/en/latest/user-guide/tasks.html#target-metadata):
+   metadata**](https://docs.hubverse.io/en/latest/user-guide/tasks.html#target-metadata):
    The caracteristics of the value modelers are trying to predict (for example,
    incident hospitalizations represent weekly step-ahead continuous count data)
 
@@ -55,13 +55,13 @@ that the model output must be in a tabular format (specified in the hub's
 The model output format is a tabluar representation of model output defined by
 the [Model Tasks](#model-tasks) for a given hub. You can find examples of model
 output and more in the [model output formats
-page](https://hubverse.io/en/latest/user-guide/model-output.html) of the
+page](https://docs.hubverse.io/en/latest/user-guide/model-output.html) of the
 official documentation.
 
 ## Target Data
 
-The target data are represented in two files: [`time-series`](https://hubverse.io/en/latest/user-guide/target-data.html#time-series) and
-[`oracle-outputs`](https://hubverse.io/en/latest/user-guide/target-data.html#oracle-output)[^1]. Each data format is
+The target data are represented in two files: [`time-series`](https://docs.hubverse.io/en/latest/user-guide/target-data.html#time-series) and
+[`oracle-outputs`](https://docs.hubverse.io/en/latest/user-guide/target-data.html#oracle-output)[^1]. Each data format is
 useful for different purposes (see table below). Modelers will most often
 estimate model parameters by fitting to the raw data in time series format.
 
@@ -72,7 +72,7 @@ estimate model parameters by fitting to the raw data in time series format.
 : Common uses for target time series and oracle output data. A ✅
 indicates which data formats are most commonly used for each purpose.
 
-You can read more in the [target data page](https://hubverse.io/en/latest/user-guide/target-data.html) of the official documentation.
+You can read more in the [target data page](https://docs.hubverse.io/en/latest/user-guide/target-data.html) of the official documentation.
 
 [^1]: oracle outputs are generated from time series
 
@@ -95,4 +95,4 @@ near-real-time to AWS:
 
 If you are interested in storing your data on AWS S3, please consult the [AWS
 onboarding
-guide](https://hubverse.io/en/latest/developer/cloud-onboarding.html)
+guide](https://docs.hubverse.io/en/latest/developer/cloud-onboarding.html)

--- a/tools/software.qmd
+++ b/tools/software.qmd
@@ -8,7 +8,7 @@ Thanks to rigorous [data standards](/tools/data.qmd), our software works on any 
 
 :::
 
-[{{< fa book >}} Full list of hubverse software](https://hubverse.io/en/latest/user-guide/software.html){.btn .btn-outline-dark .ms-auto}
+[{{< fa book >}} Full list of hubverse software](https://docs.hubverse.io/en/latest/user-guide/software.html){.btn .btn-outline-dark .ms-auto}
 
 The hubverse has a wide range of software packages designed to help you **administer hubs**, **validate** and **evaluate** model outputs, **access hub data**, **ensemble** and **visualize** models.
 


### PR DESCRIPTION
This PR updates `hubverse.io` URLs to point to `docs.hubverse.io`.

📝 Multiple commits — feel free to **Squash and Merge** to keep history clean.