### PR TITLE
update community icon

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -59,7 +59,7 @@ website:
         - icon: info-circle-fill
           href: "about.qmd"
         - text: "---"
-        - text: "{{< fa people-pulling >}} Community"
+        - text: "{{< fa people-line >}} Community"
         - text: "Get Involved"
           href: community/index.qmd
         - community/hubs.qmd

--- a/index.qmd
+++ b/index.qmd
@@ -30,8 +30,8 @@ NOTE: the `include` directives below are needed to load the metadata that are us
 ## Improving public health outcomes through collaborative modeling {.subtitle}
 
 ::::{.breakin}
-<!-- [{{< fa people-line >}} community](/community/index.qmd){.btn .btn-outline-dark .ms-auto} -->
-[{{< fa people-pulling >}} Community](/community/index.qmd){.btn .btn-outline-dark .ms-auto}
+[{{< fa people-line >}} community](/community/index.qmd){.btn .btn-outline-dark .ms-auto}
+<!-- [{{< fa people-pulling >}} Community](/community/index.qmd){.btn .btn-outline-dark .ms-auto} -->
 [{{< fa compass >}} Data Standards](/tools/data.qmd){.btn .btn-outline-dark .ms-auto}
 [{{< fa tools >}} Software](/tools/software.qmd){.btn .btn-outline-dark .ms-auto}
 [{{< fa circle-info >}} About](/about.qmd){.btn .btn-outline-dark .ms-auto}


### PR DESCRIPTION
This updates the community logo to be less cheeky:

Before:
![screencapture of community logo that's two silhouettes that looks like one is pulling a petulant child](https://github.com/user-attachments/assets/170958f7-85ca-4ae8-a44d-1ee85577ee9f)

After: 
![screencapture of community logo that's three silhouettes above a line](https://github.com/user-attachments/assets/9ea277dc-745d-4e64-a490-5334330ceb63)
