### PR TITLE
set the 404 redirect to the correct page

### DIFF
--- a/docs-redirect.html
+++ b/docs-redirect.html
@@ -5,6 +5,6 @@
     path.startsWith("/en/stable") ||
     path.includes("/en/")
   ) {
-    window.location.href = "https://docs.hubverse.io";
+    window.location.href = "https://docs.hubverse.io" + path;
   }
 </script>


### PR DESCRIPTION
I noticed when I tried to go to https://hubverse.io/en/latest/user-guide/dashboards.html, I was redirected to https://docs.hubverse.io/ instead of https://docs.hubverse.io/en/latest/user-guide/dashboards.html

This will fix that issue. 