### PR TITLE
allow for private hubs

### DIFF
--- a/.github/ISSUE_TEMPLATE/HUB.yml
+++ b/.github/ISSUE_TEMPLATE/HUB.yml
@@ -54,10 +54,10 @@ body:
     id: github
     attributes:
       label: GitHub slug
-      description: The github slug of your hub without the https://github.com part
+      description: The github slug of your hub without the https://github.com part. If your hub is private, you may skip this.
       placeholder: reichlab/variant-nowcast-hub
     validations:
-      required: true
+      required: false
   - type: input
     attributes:
       label: Contact

--- a/_data/active-hubs.qmd
+++ b/_data/active-hubs.qmd
@@ -20,13 +20,14 @@ hubs:
         multiple lines
       # from admin.json
       contact: "hub-info@example.com"
-      repo: "example-org/hub-name" # must be slug, not URL
       license: "License Name (e.g MIT License)"
       # --- OPTIONAL ----
+      # repo: "example-org/hub-name" # must be slug, not URL
       aws: "aws-bucket-name" # from your admin.json
       insights: https://example.org/hub-insights/
       forecasts: https://example.org/hub-insights/forecasts.html
       evals: https://example.org/hub-insights/evals.html
+      count: 5 # number of models submitted (this is automatically updated if your hub is public)
   hubverse:
     logo: /logo/logo-with-text.png
     name: "The hubverse"

--- a/_partials/hub.qmd
+++ b/_partials/hub.qmd
@@ -34,6 +34,7 @@
                     {{/contact}}
                 </p>
                 <ul class="list-group list-group-flush">
+                    {{#repo}}
                     <li class="list-group-item">
                     <a class="card-link" href="https://github.com/{{.repo}}">
                     <i class="fa-brands fa-github"></i>
@@ -46,6 +47,13 @@
                     Submission Instructions
                     </a>
                     </li>
+                    {{/repo}}
+                    {{^repo}}
+                    <li class="list-group-item">
+                    <i class="fa-solid fa-lock"></i>
+                    <span class="visually-hidden">{{name}} </span><span aria-hidden=true>Private Hub</span>
+                    </li>
+                    {{/repo}}
                     {{#insights}}
                     <li class="list-group-item">
                     <a class="card-link" href="{{.insights}}">


### PR DESCRIPTION
This will fix #23

Instead of displaying a link to the hub, it will display a lock with "Private Hub"

![screenshot of card as described above](https://github.com/user-attachments/assets/4acae5d6-8480-48cf-998a-f7888c6e8c43)



