### PR TITLE
add docs menu item

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -74,6 +74,8 @@ website:
         - text: "Funding"
           href: "funding.md"
         - "CONTRIBUTING.md"
+      - text: "{{< fa book >}} Docs {{< fa arrow-up-right-from-square >}}"
+        href: https://docs.hubverse.io/
   page-footer:
     left:
       - icon: c-circle


### PR DESCRIPTION
This adds a docs menu item:

![menu bar that shows five items: home, get started, tools, about, and docs](https://github.com/user-attachments/assets/165f3c82-f63f-48e9-8f95-b8c03fb8939b)
