### PR TITLE
it all started trying to run quarto preview

### DIFF
--- a/about.qmd
+++ b/about.qmd
@@ -108,6 +108,6 @@ The Consortium of Infectious Disease Modeling Hubs. The hubverse: open tools for
 Here are links to presentations about the hubverse (starting with the most recent):
 
 - Presentation about the hubverse project given during the first Insight Net Quarterly Seminar - [video](https://youtu.be/RF5_V2SEbnA?si=iBsmitzG9qLmIiE1) (18 June 2024).
-- "Hubverse: Supporting modeling hubs across the globe" presentation given at the ECDC RespiCast Hub Launch - [slides](../includes/files/202311-ecdc-hub-launch.pdf) (20 November 2023).
+- "Hubverse: Supporting modeling hubs across the globe" presentation given at the ECDC RespiCast Hub Launch - [slides](/includes/files/202311-ecdc-hub-launch.pdf) (20 November 2023).
 - Overview on the hubverse to CDC and CFA - [video](https://www.youtube.com/watch?v=aLVF90zwM-E) and [slides](https://docs.google.com/presentation/d/e/2PACX-1vRhXa7DgUDATi3Ovzc8rmUADD9aWeaZKkDV-2wXmja4KT0PJV7elsWiNRHCj9ypRaFEGoFNumOP2mhS/pub?start=false&loop=false&delayms=3000) (09 June 2023).
 

--- a/terminology.qmd
+++ b/terminology.qmd
@@ -71,7 +71,7 @@ representing the outcomes of multiple efforts.
 
 [Task]{#task}
 : a definition of the goals of a modeling effort, possibly including
-  conditions, assumptions, and [targets](#target) (colectively known as [task
+  conditions, assumptions, and [targets](#target) (collectively known as [task
   ID variables](#taskid)). Some tasks may be fixed across [rounds](#round),
   such as for forecast hubs that regularly solicit predictions for a set time
   horizon in the near-term future. Other tasks may be more variable; for


### PR DESCRIPTION
I ran into a few problems running quarto preview (which I haven't fully solved), but saw three issues I tried to solve here:
1. There should be a presentation in `/includes/files/202311...launch.pdf` which wasn't there (referenced in about.qmd -> presentations.
2. There wasn't a folder called files, but rather some file named `files` that I couldn't figure out what it did or was for.
3. I didn't want to delete that file, so I moved it into `includes/files/` and added the presentation file to that folder.
4. I fixed a typo.