### PR TITLE
Redirect contributors page (it only works with docs v 5.1.0)

### DIFF
--- a/docs-redirect.html
+++ b/docs-redirect.html
@@ -3,12 +3,20 @@
 
   if (
     (
-      path.startsWith("/en/latest") || 
+      path.startsWith("/en/latest") ||
       path.startsWith("/en/stable")
-    ) && 
+    ) &&
     path.includes("overview/history.html")
   ) {
     window.location.href = "https://hubverse.io/about.html#history";
+  } else if (
+    (
+      path.startsWith("/en/latest") ||
+      path.startsWith("/en/stable")
+    ) &&
+    path.includes("overview/contributors.html")
+  ) {
+    window.location.href = "https://hubverse.io/community/contributors.html";
   } else if (
     path.startsWith("/en/latest") ||
     path.startsWith("/en/stable") ||


### PR DESCRIPTION
As proposed in [this discussion](https://github.com/orgs/hubverse-org/discussions/37#discussioncomment-13564285), this PR:
- Adds a redirect from the hubverse site, as was suggested when deleting the history page.
- After testing, this only works with v 5.1.0, as that is the only old version that has the contributors page