### PR TITLE
reorder link bubbles

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -29,14 +29,6 @@ NOTE: the `include` directives below are needed to load the metadata that are us
 
 ## Improving public health outcomes through collaborative modeling {.subtitle}
 
-::::{.breakin}
-[{{< fa people-line >}} community](/community/index.qmd){.btn .btn-outline-dark .ms-auto}
-<!-- [{{< fa people-pulling >}} Community](/community/index.qmd){.btn .btn-outline-dark .ms-auto} -->
-[{{< fa compass >}} Data Standards](/tools/data.qmd){.btn .btn-outline-dark .ms-auto}
-[{{< fa tools >}} Software](/tools/software.qmd){.btn .btn-outline-dark .ms-auto}
-[{{< fa circle-info >}} About](/about.qmd){.btn .btn-outline-dark .ms-auto}
-
-
 Use the hubverse data standards and software to:
 
  - [{{< fa handshake-simple >}} **Collaborate**]{.look-here} with modelers around the world
@@ -48,6 +40,13 @@ Use the hubverse data standards and software to:
 ![](/includes/img/showcase.png){.breakout alt="screenshots of successful model submissions paired with screenshots of dashboards showing forecast and evaluation visualizations for the flusight hub"}
 
 [**Get started with [**a gentle introduction to modeling hubs**](quickstart/index.html).**]{.breakin}
+
+::::{.breakin}
+[{{< fa people-line >}} community](/community/index.qmd){.btn .btn-outline-dark .ms-auto}
+<!-- [{{< fa people-pulling >}} Community](/community/index.qmd){.btn .btn-outline-dark .ms-auto} -->
+[{{< fa compass >}} Data Standards](/tools/data.qmd){.btn .btn-outline-dark .ms-auto}
+[{{< fa tools >}} Software](/tools/software.qmd){.btn .btn-outline-dark .ms-auto}
+[{{< fa circle-info >}} About](/about.qmd){.btn .btn-outline-dark .ms-auto}
 
 :::
 

--- a/index.qmd
+++ b/index.qmd
@@ -29,15 +29,15 @@ NOTE: the `include` directives below are needed to load the metadata that are us
 
 ## Improving public health outcomes through collaborative modeling {.subtitle}
 
+:::{.breakin}
 Use the hubverse data standards and software to:
 
- - [{{< fa handshake-simple >}} **Collaborate**]{.look-here} with modelers around the world
- - [{{< fa retweet >}} **Share**]{.look-here} insights in real time
- - [{{< fa person-chalkboard >}} **Inform**]{.look-here} critical decisions with **robust and validated** model outputs
+  - [{{< fa handshake-simple >}} **Collaborate**]{.look-here} with modelers around the world
+  - [{{< fa retweet >}} **Share**]{.look-here} insights in real time
+  - [{{< fa person-chalkboard >}} **Inform**]{.look-here} critical decisions with **robust and validated** model outputs
+:::
 
-::::
-
-![](/includes/img/showcase.png){.breakout alt="screenshots of successful model submissions paired with screenshots of dashboards showing forecast and evaluation visualizations for the flusight hub"}
+ ![](/includes/img/showcase.png){.breakout alt="screenshots of successful model submissions paired with screenshots of dashboards showing forecast and evaluation visualizations for the flusight hub"}
 
 [**Get started with [**a gentle introduction to modeling hubs**](quickstart/index.html).**]{.breakin}
 
@@ -47,6 +47,8 @@ Use the hubverse data standards and software to:
 [{{< fa compass >}} Data Standards](/tools/data.qmd){.btn .btn-outline-dark .ms-auto}
 [{{< fa tools >}} Software](/tools/software.qmd){.btn .btn-outline-dark .ms-auto}
 [{{< fa circle-info >}} About](/about.qmd){.btn .btn-outline-dark .ms-auto}
+
+::::
 
 :::
 
@@ -135,7 +137,4 @@ Do you have a hub, but it's not listed? [{{< fa question-circle >}} Tell us abou
 :::
 
 :::
-
-
-
 


### PR DESCRIPTION
This PR moves the bubbles for community, data standards, software and about, to go below the link to a "gentle introduction to modeling hubs." It makes more sense to me to have the gentle introduction be the first link available, and then present all the other technical links. Please let me know if you disagree.