### PR TITLE
Move presentations from hubDocs to hubverse-site

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -66,6 +66,8 @@ website:
           href: https://docs.hubverse.io/
         - text: "{{< fa coins >}} Funding"
           href: "funding.md"
+        - text: "{{< fa person-chalkboard >}} Presentations"
+          href: "presentations.md"
         - icon: github
           text: "Contributing to the site"
           href: "CONTRIBUTING.md"

--- a/docs-redirect.html
+++ b/docs-redirect.html
@@ -13,7 +13,8 @@
     "overview/who-we-are.html": "https://hubverse.io/about.html",
     "overview/scope.html": "https://hubverse.io/about.html#scope",
     "overview/support-consulting.html": "https://hubverse.io/quickstart/support-consulting.html",
-    "overview/data-storage.html": "https://docs.hubverse.io/en/latest/user-guide/data-storage.html"
+    "overview/data-storage.html": "https://docs.hubverse.io/en/latest/user-guide/data-storage.html",
+    "user-guide/presentations.html": "https://hubverse.io/presentations.html"
   };
 
   const versionedPathRegex = /^\/en\/(\d+\.\d+\.\d+|latest|stable)\//;

--- a/presentations.md
+++ b/presentations.md
@@ -1,0 +1,10 @@
+---
+title: '{{< fa person-chalkboard >}} Presentations'
+---
+
+Here are links to presentations about the hubverse:
+
+- Presentation about the hubverse project given during the first Insight Net Quarterly Seminar - [video](https://youtu.be/RF5_V2SEbnA?si=iBsmitzG9qLmIiE1) (18 June 2024).
+- "Hubverse: Supporting modeling hubs across the globe" presentation given at the ECDC RespiCast Hub Launch - [slides](includes/files/202311-ecdc-hub-launch.pdf) (20 November 2023).
+- Overview on the hubverse to CDC and CFA - [video](https://www.youtube.com/watch?v=aLVF90zwM-E) and [slides](https://docs.google.com/presentation/d/e/2PACX-1vRhXa7DgUDATi3Ovzc8rmUADD9aWeaZKkDV-2wXmja4KT0PJV7elsWiNRHCj9ypRaFEGoFNumOP2mhS/pub?start=false&loop=false&delayms=3000) (09 June 2023).
+

--- a/presentations.md
+++ b/presentations.md
@@ -4,6 +4,7 @@ title: '{{< fa person-chalkboard >}} Presentations'
 
 Here are links to presentations about the hubverse:
 
+- Presentations from regular hubverse community meetings - [folder](https://drive.google.com/drive/u/1/folders/1OGXf2V-gejEYOC-kYvZo2Zqj3EdCGTE5?ths=true) (ongoing since 2023-10-04).
 - Presentation about the hubverse project given during the first Insight Net Quarterly Seminar - [video](https://youtu.be/RF5_V2SEbnA?si=iBsmitzG9qLmIiE1) (18 June 2024).
 - "Hubverse: Supporting modeling hubs across the globe" presentation given at the ECDC RespiCast Hub Launch - [slides](includes/files/202311-ecdc-hub-launch.pdf) (20 November 2023).
 - Overview on the hubverse to CDC and CFA - [video](https://www.youtube.com/watch?v=aLVF90zwM-E) and [slides](https://docs.google.com/presentation/d/e/2PACX-1vRhXa7DgUDATi3Ovzc8rmUADD9aWeaZKkDV-2wXmja4KT0PJV7elsWiNRHCj9ypRaFEGoFNumOP2mhS/pub?start=false&loop=false&delayms=3000) (09 June 2023).


### PR DESCRIPTION
This PR transfers the content of "presentations", which is currently in the User Guide in hubDocs to the hubverse site. Additionally it adds a redirect for people looking for the old page, as has been done with all pages from hubDocs that have been removed.