### PR TITLE
Fix to workflow updating Quarto extensions

### DIFF
--- a/.github/workflows/update-quarto-extensions.yml
+++ b/.github/workflows/update-quarto-extensions.yml
@@ -24,17 +24,37 @@ jobs:
           quarto add quarto-ext/fontawesome --no-prompt
 
       - name: Open pull request if extensions changed
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 #v8.1.1
-        with:
-          commit-message: "chore: update Quarto extensions"
-          title: "chore: update Quarto extensions"
-          body: |
-            Automated weekly update of Quarto extensions.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "No changes to extensions, skipping PR."
+            exit 0
+          fi
 
-            Extensions updated:
-            - `gadenbuie/partials`
-            - `quarto-ext/fontawesome`
+          BRANCH="automated/update-quarto-extensions"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add -A
+          git commit -m "chore: update Quarto extensions"
+          git push --force origin "$BRANCH"
 
-            The render test in the publish workflow will verify these changes work correctly.
-          branch: automated/update-quarto-extensions
-          delete-branch: true
+          if gh pr list --head "$BRANCH" --state open | grep -q "$BRANCH"; then
+            echo "PR already open for $BRANCH, skipping creation."
+          else
+            gh pr create \
+              --title "chore: update Quarto extensions" \
+              --body "$(cat <<'EOF'
+          Automated weekly update of Quarto extensions.
+
+          Extensions updated:
+          - \`gadenbuie/partials\`
+          - \`quarto-ext/fontawesome\`
+
+          The render test in the publish workflow will verify these changes work correctly.
+          EOF
+          )" \
+              --base main \
+              --head "$BRANCH"
+          fi


### PR DESCRIPTION
In order to update Quarto extensions, Claude helped write code that used `peter-evans/create-pull-request` to create PRs if there were updates (similar to Dependabot). But, that's not allowed in `hubverse-org`, so Claude helped me with a workaround.