### PR TITLE
A few fixes for the list of hubs page

### DIFF
--- a/_data/active-hubs.qmd
+++ b/_data/active-hubs.qmd
@@ -112,7 +112,8 @@ hubs:
         repo: reichlab/variant-nowcast-hub
         license: MIT License
         aws: "covid-variant-nowcast-hub"
-        insights: https://reichlab.io/variant-nowcast-hub-dashboard/
+        insights: https://reichlab.io/variant-nowcast-hub-dashboard/explore.html
+        evals: https://reichlab.io/variant-nowcast-hub-dashboard/eval.html
         count: 11
       - name: "Flu MetroCast Hub"
         description: "The Flu MetroCast Hub is a modeling hub with the goal of\ncollecting city- and county-level forecasts of influenza\nactivity. The hub is led by the epiENGAGE team from UT-Austin\nand UMass-Amherst, as a part of the CDC Insight Net program."

--- a/community/hubs.qmd
+++ b/community/hubs.qmd
@@ -105,7 +105,7 @@ sys.path.insert(0, str(Path("..").resolve()))
 from scripts.hub_table import build_hub_dataframe, canon_repo_key, load_hub_row_counts
 
 df = build_hub_dataframe(Path("../_data/active-hubs.qmd"))
-df = df.sort_values("Hub", ascending=False).reset_index(drop=True)
+df = df.sort_values("Hub", key=lambda s: s.str.lower(), ascending=False).reset_index(drop=True)
 hub_row_counts = load_hub_row_counts(Path("../output/hub_stats_summary.csv"))
 
 CATEGORY_BADGE = {

--- a/community/hubs.qmd
+++ b/community/hubs.qmd
@@ -105,6 +105,7 @@ sys.path.insert(0, str(Path("..").resolve()))
 from scripts.hub_table import build_hub_dataframe, canon_repo_key, load_hub_row_counts
 
 df = build_hub_dataframe(Path("../_data/active-hubs.qmd"))
+df = df.sort_values("Hub", ascending=False).reset_index(drop=True)
 hub_row_counts = load_hub_row_counts(Path("../output/hub_stats_summary.csv"))
 
 CATEGORY_BADGE = {
@@ -153,7 +154,7 @@ display(HTML(f"""
 </style>
 <script>
 (function() {{
-  var sortCol = -1, sortDir = 1;
+  var sortCol = 0, sortDir = -1;
 
   function sortHubTable(colIndex) {{
     var table = document.getElementById('hub-table');
@@ -198,6 +199,7 @@ display(HTML(f"""
     document.querySelectorAll('#hub-table thead th.sortable').forEach(function(th, i) {{
       th.addEventListener('click', function() {{ sortHubTable(i); }});
     }});
+    document.querySelectorAll('#hub-table thead th')[0].classList.add('sort-desc');
     document.getElementById('hub-search').addEventListener('input', filterHubTable);
   }});
 }})();

--- a/scripts/hub_table.py
+++ b/scripts/hub_table.py
@@ -89,10 +89,7 @@ def build_hub_dataframe(path: Path) -> pd.DataFrame:
                         else '<span class="text-muted fst-italic">private</span>'
                     ),
                     "Open Data": (
-                        resource_link(
-                            "https://hubverse-org.github.io/hubData/articles/connect_hub.html",
-                            f"s3://{hub['aws']}",
-                        )
+                        '<span class="text-success fw-bold">✓</span>'
                         if hub.get("aws")
                         else ""
                     ),

--- a/scripts/hub_table.py
+++ b/scripts/hub_table.py
@@ -89,7 +89,7 @@ def build_hub_dataframe(path: Path) -> pd.DataFrame:
                         else '<span class="text-muted fst-italic">private</span>'
                     ),
                     "Open Data": (
-                        f'<span class="text-success fw-bold" title="s3://{hub[\"aws\"]}">✓</span>'
+                        f'<span class="text-success fw-bold" title="s3://{hub["aws"]}">✓</span>'
                         if hub.get("aws")
                         else ""
                     ),

--- a/scripts/hub_table.py
+++ b/scripts/hub_table.py
@@ -89,7 +89,7 @@ def build_hub_dataframe(path: Path) -> pd.DataFrame:
                         else '<span class="text-muted fst-italic">private</span>'
                     ),
                     "Open Data": (
-                        '<span class="text-success fw-bold">✓</span>'
+                        f'<span class="text-success fw-bold" title="s3://{hub[\"aws\"]}">✓</span>'
                         if hub.get("aws")
                         else ""
                     ),


### PR DESCRIPTION
This PR closes #112 :
1. It changes how hubs are displayed by default in the table
2. Removes the "Open Data" links on the table, which were pointless.
3. Reviewed and added one link for the Variant Nowcast Hub.