### PR TITLE
Update "welcome to the new hubverse site" announcement

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -7,6 +7,12 @@ project:
   resources:
     - docs-redirect.html
 website:
+  announcement:
+    icon: baloon #megaphone
+    dismissable: true
+    content: "Welcome to the hubverse. Discover [our community](/community/index.qmd), get involved, or reach out to share your feedback."
+    type: info
+    position: above-navbar
   favicon: /brand/logo/logo.png
   title: "hubverse"
   site-url: "https://hubverse.io"

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -7,12 +7,6 @@ project:
   resources:
     - docs-redirect.html
 website:
-  announcement:
-    icon: baloon #megaphone
-    dismissable: true
-    content: "Welcome to the new hubverse site. If you have any comments, feel free to [provide feedback](https://github.com/hubverse-org/hubverse-site/issues/new)"
-    type: info
-    position: above-navbar
   favicon: /brand/logo/logo.png
   title: "hubverse"
   site-url: "https://hubverse.io"


### PR DESCRIPTION
The website has been operational for over a year (no longer that new), and the banner directs you to GitHub issues, which doesn't seem like an ideal way to communicate with a broad audience.