### PR TITLE
fix: add archived target-data dirs and force RespiCompass re-fetch

### DIFF
--- a/_data/active-hubs.qmd
+++ b/_data/active-hubs.qmd
@@ -307,6 +307,7 @@ hubs:
         count: 11
         archived_dirs:
           - "Previous_Rounds/*/model-output"
+          - "Previous_Rounds/*/target-data"
   ecdc-archival:
     name: "European Centre for Disease Prevention and Control (ECDC)"
     logo: /includes/img/ecdc.png

--- a/output/hub_stats/fetch_cache.json
+++ b/output/hub_stats/fetch_cache.json
@@ -10,7 +10,6 @@
   "dailypartita/China-COVID-19-Forecast-Hub": "2026-05-15T02:07:38Z",
   "european-modelling-hubs/RespiCast-Covid19": "2026-06-15T21:51:37Z",
   "european-modelling-hubs/RespiCast-SyndromicIndicators": "2026-06-15T21:53:04Z",
-  "european-modelling-hubs/RespiCompass": "2026-06-15T10:59:09Z",
   "european-modelling-hubs/ari-forecast-hub_archive": "2025-04-14T09:17:36Z",
   "european-modelling-hubs/flu-forecast-hub_archive": "2025-04-14T09:17:54Z",
   "hubverse-org/covid19-forecast-hub-archive": "2026-06-06T01:09:48Z",

--- a/scripts/update_model_counts.sh
+++ b/scripts/update_model_counts.sh
@@ -3,13 +3,13 @@
 # Update Hub Model Counts
 #
 # This script will update the YAML header of _active-hubs.qmd by querying the
-# GitHub API 
-# 
+# GitHub API
+#
 # USAGE:
 #   bash scripts/update_model_counts.sh [file]
 #
 # ARGUMENTS:
-#   
+#
 #   file  path to the active hubs file. This defaults to
 #         `community/_active-hubs.qmd` and assumes you are working in the
 #         current working directory.
@@ -41,32 +41,66 @@ model_output_api_path() {
   fi
 }
 
+# Count model subdirectories across an archived glob pattern like
+# "Previous_Rounds/*/model-output". Ignores patterns not ending in model-output.
+# Expands the single '*' by listing the parent directory, then counts subdirs
+# in each matched path using the GitHub Contents API.
+count_archived_model_output() {
+  local repo="${1%/}"
+  local pattern="$2"
+
+  # Only count patterns that end in model-output
+  [[ "${pattern}" != */model-output ]] && echo 0 && return
+
+  local prefix="${pattern%%\**}"   # e.g. "Previous_Rounds/"
+  local suffix="${pattern##*\*}"   # e.g. "/model-output"
+  prefix="${prefix%/}"             # strip trailing slash
+
+  local total=0
+  local round n
+  while IFS= read -r round; do
+    [[ -z "${round}" ]] && continue
+    n=$(gh api "/repos/${repo}/contents/${prefix}/${round}${suffix}" \
+          --jq '[.[] | select(.type=="dir")] | length' 2>/dev/null)
+    if [[ "${n}" =~ ^[0-9]+$ ]]; then
+      total=$((total + n))
+    fi
+  done < <(gh api "/repos/${repo}/contents/${prefix}" \
+             --jq '.[] | select(.type=="dir") | .name' 2>/dev/null)
+
+  echo "${total}"
+}
+
 # get array of hub repo locations from the file
 mapfile -t hubs < <(yq --front-matter=extract '.hubs[].hubs[] | .repo' "${hub_file}")
 
 selector='[.[] | select((.type == "dir"))] | length'
 re='^[0-9]+$'
 for hub in "${hubs[@]}"; do
-  # 1. Use the GitHub API to count the number of directories in `model-output`
-  n=$(gh api "$(model_output_api_path "${hub}")" --jq "$selector")
-  if [[ "${n}" =~ $re && "${n}" -gt 0 ]]; then
+  # 1. Count subdirectories in the root model-output (may be 0 if data has moved
+  #    to archived rounds).
+  n=$(gh api "$(model_output_api_path "${hub}")" --jq "$selector" 2>/dev/null)
+  [[ ! "${n}" =~ $re ]] && n=0
+
+  # 2. Add counts from any archived model-output patterns defined in archived_dirs.
+  while IFS= read -r pattern; do
+    [[ -z "${pattern}" ]] && continue
+    extra=$(count_archived_model_output "${hub}" "${pattern}")
+    if [[ "${extra}" =~ $re ]]; then
+      n=$((n + extra))
+    fi
+  done < <(yq --front-matter=extract \
+    '.hubs[].hubs[] | select(.repo == "'"${hub%/}"'") | .archived_dirs[]?' \
+    "${hub_file}" 2>/dev/null)
+
+  if [[ "${n}" -gt 0 ]]; then
     echo "${hub%/} has ${n} models"
-    # 2. Use yq to update that number in the frontmatter
-    #    -i                      update file in place
-    #    --front-matter=process  process the frontmatter, but leave the rest of
-    #      the file in tact
-    #
-    #    `with`: https://mikefarah.gitbook.io/yq/operators/with
-    #    `select`: https://mikefarah.gitbook.io/yq/operators/select
-    #    `|` (pipe): https://mikefarah.gitbook.io/yq/operators/pipe
-    #    `|=` (assignment): https://mikefarah.gitbook.io/yq/operators/assign-update
+    # 3. Update the count in the frontmatter.
     yq -i --front-matter=process '
     with(.hubs[].hubs[];
       select(.repo == "'"${hub%/}"'") | .count |= '"${n}"'
     )' "${hub_file}"
   else
     echo "${hub} has an unknown number of models"
-    count="missing"
   fi
 done
-

--- a/tests/fixtures/example_active-hubs.qmd
+++ b/tests/fixtures/example_active-hubs.qmd
@@ -37,5 +37,20 @@ hubs:
         repo: "example-subdir-org/monorepo/tree/main/example-subdir-hub"
         license: "MIT License"
         count: 2
+  example-archived-org:
+    logo: /includes/img/example-logo.png
+    name: "Example Archived Org"
+    hubs:
+      - name: "Example Archived Hub"
+        description: "A hub whose model-output has moved to archived round subdirectories"
+        contact:
+          - name: "Maintainer name"
+            email: "maintainer.email@example.com"
+        repo: "example-archived-org/example-archived-hub"
+        license: "MIT License"
+        count: 0
+        archived_dirs:
+          - "Previous_Rounds/*/model-output"
+          - "Previous_Rounds/*/target-data"
 ---
 

--- a/tests/stubs/gh
+++ b/tests/stubs/gh
@@ -45,6 +45,16 @@ if [[ "$jq_arg" == ".default_branch" ]]; then
   exit 0
 fi
 
+# Listing subdirectory names (used when expanding archived_dirs glob patterns).
+# Returns one directory name per line from GH_ROUNDS_<sanitized_path>.
+if [[ "$jq_arg" == '.[] | select(.type=="dir") | .name' ]]; then
+  rounds_var="GH_ROUNDS_$(sanitize "$repo_path")"
+  if [[ -n "${!rounds_var:-}" ]]; then
+    echo "${!rounds_var}"
+  fi
+  exit 0
+fi
+
 if [[ "$repo_path" == */model-output ]]; then
   stripped="${repo_path%/model-output}"
   if [[ "$stripped" == */contents ]]; then

--- a/tests/test_update_model_counts.bats
+++ b/tests/test_update_model_counts.bats
@@ -51,6 +51,54 @@ setup() {
   [ "$count" = "7" ]
 }
 
+@test "sums model counts across archived round directories" {
+  if ! command -v yq >/dev/null; then
+    skip "yq must be installed for this test"
+  fi
+
+  local hub_file="${BATS_TEST_TMPDIR}/example_active-hubs.qmd"
+  cp "${BATS_TEST_DIRNAME}/fixtures/example_active-hubs.qmd" "$hub_file"
+
+  # Root model-output is empty; two archived rounds each have teams
+  export GH_COUNT_example_archived_org_example_archived_hub=0
+  export GH_ROUNDS_example_archived_org_example_archived_hub_contents_Previous_Rounds="2024-2025_round_1
+2025-2026_round_1"
+  export GH_COUNT_example_archived_org_example_archived_hub_Previous_Rounds_2024_2025_round_1=15
+  export GH_COUNT_example_archived_org_example_archived_hub_Previous_Rounds_2025_2026_round_1=13
+
+  run "${BATS_TEST_DIRNAME}/../scripts/update_model_counts.sh" "$hub_file"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"example-archived-org/example-archived-hub has 28 models"* ]]
+
+  local count
+  count=$(yq --front-matter=extract '.hubs[].hubs[] | select(.repo == "example-archived-org/example-archived-hub") | .count' "$hub_file")
+  [ "$count" = "28" ]
+}
+
+@test "ignores archived_dirs patterns that do not end in model-output" {
+  if ! command -v yq >/dev/null; then
+    skip "yq must be installed for this test"
+  fi
+
+  local hub_file="${BATS_TEST_TMPDIR}/example_active-hubs.qmd"
+  cp "${BATS_TEST_DIRNAME}/fixtures/example_active-hubs.qmd" "$hub_file"
+
+  export GH_COUNT_example_archived_org_example_archived_hub=0
+  export GH_ROUNDS_example_archived_org_example_archived_hub_contents_Previous_Rounds="2024-2025_round_1"
+  export GH_COUNT_example_archived_org_example_archived_hub_Previous_Rounds_2024_2025_round_1=10
+
+  run "${BATS_TEST_DIRNAME}/../scripts/update_model_counts.sh" "$hub_file"
+
+  [ "$status" -eq 0 ]
+  # target-data pattern should be ignored; only the model-output round contributes
+  [[ "$output" == *"example-archived-org/example-archived-hub has 10 models"* ]]
+
+  local count
+  count=$(yq --front-matter=extract '.hubs[].hubs[] | select(.repo == "example-archived-org/example-archived-hub") | .count' "$hub_file")
+  [ "$count" = "10" ]
+}
+
 @test "leaves count unchanged when gh result is not positive" {
   if ! command -v yq >/dev/null; then
     skip "yq must be installed for this test"


### PR DESCRIPTION
Add Previous_Rounds/*/target-data to RespiCompass archived_dirs so target-data rows from both rounds are counted alongside model-output. Remove RespiCompass from fetch_cache.json so the next action run re-fetches it without requiring --force.