### PR TITLE
remove redundant make models from Netlify; document hosting setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,10 @@ Quarto-based static website for [hubverse.io](https://hubverse.io). Built with
 Python scripts for data generation, BASH scripts for hub metadata, and two
 GitHub Actions workflows for automated updates.
 
+The live site is **served by GitHub Pages** (published by `publish.yml`).
+**Netlify only builds PR deploy previews** (`netlify.toml`, `netlify-build.sh`)
+— it does not serve production.
+
 ## Commands
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,19 @@ Finally, there are _build process_ files and folders:
  - `Makefile` is a helper that allows us to port the build process anywhere
  - `.github/workflows/publish.yml` runs all the scripts and publishes the quarto
    site to gh pages.
+ - `netlify.toml` and `netlify-build.sh` configure Netlify deploy previews.
+
+## Where the site is hosted
+
+The live site at [hubverse.io](https://hubverse.io) is **served by GitHub
+Pages**, published by [`.github/workflows/publish.yml`](.github/workflows/publish.yml)
+whenever changes land on `main`.
+
+**Netlify is only used to build deploy previews for pull requests** (see
+`netlify.toml` and `netlify-build.sh`), so reviewers can preview changes before
+merging. It does not serve the production site. Changes that affect the live
+site should target the GitHub Pages build process; Netlify config only needs to
+change if the PR-preview build itself needs to change.
 
 
 ## How to add a testimonial

--- a/netlify-build.sh
+++ b/netlify-build.sh
@@ -46,8 +46,11 @@ pip install -r requirements/requirements.txt
 # Generate content (requires GITHUB_TOKEN in Netlify environment variables)
 # --------------------------------------------------------------------------- #
 echo "Generating content..."
+# Note: `make models` is intentionally omitted. Model counts in
+# _data/active-hubs.qmd are updated and committed by the Update Hub Stats
+# workflow, so running it here would trigger redundant GitHub API calls and
+# risk rate-limiting (see .github/workflows/publish.yml).
 make contributors
-make models
 make terminology
 make cite
 


### PR DESCRIPTION
## Summary

- Removes `make models` from `netlify-build.sh`, matching the earlier
  removal from `publish.yml`. Model counts are updated and committed by
  the Update Hub Stats workflow, so running the script during Netlify
  PR-preview builds triggered redundant GitHub API calls and risked
  rate-limiting.
- Documents in `CONTRIBUTING.md` and `CLAUDE.md` that the live site is
  served by GitHub Pages while Netlify is only used for PR deploy
  previews, so contributors know where changes take effect.